### PR TITLE
[Feature] Headless Mode

### DIFF
--- a/client/DebugLog.cs
+++ b/client/DebugLog.cs
@@ -236,6 +236,10 @@ public static class DebugLog
             }
             logSemaphore.Release();
         }
+        
+        if (Settings.Headless)
+            Console.WriteLine(debugString);
+        
         LogText += debugString;
     }
 
@@ -278,6 +282,10 @@ public static class DebugLog
             }
             logSemaphore.Release();
         }
+
+        if (Settings.Headless)
+            Console.WriteLine(debugString);
+
         LogText += debugString;
     }
 

--- a/client/Frontend/App.xaml
+++ b/client/Frontend/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:specify_client"
-             StartupUri="\Frontend\Landing.xaml" Startup="Application_Startup">
+             Startup="Application_Startup">
     <Application.Resources>
         <ResourceDictionary>
             <Style TargetType="Button" x:Key="MainButtons">

--- a/client/Frontend/App.xaml.cs
+++ b/client/Frontend/App.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using specify_client.data;
 using System.Windows;
 using System;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace specify_client;
 
@@ -9,28 +11,107 @@ namespace specify_client;
 /// </summary>
 public partial class App : Application
 {
-    private void Application_Startup(object sender, StartupEventArgs e)
+
+    [DllImport("Kernel32.dll")]
+    public static extern bool AllocConsole();
+
+    [DllImport("kernel32.dll")]
+    private static extern bool FreeConsole();
+
+    [STAThread]
+    private async void Application_Startup(object sender, StartupEventArgs e)
     {
         // Calling GetSystemMetrics with value 67 asks Windows if it's running in safe mode.
         // Returns 0 for a standard boot, 1 for Safe Mode, 2 for Safe Mode w/ Networking.
         // Specify cannot properly gather information in safe mode and must be stopped prior to operation.
         var bootType = Interop.GetSystemMetrics(67);
-        if(bootType != 0)
+
+        if (e.Args.Contains("-h"))
         {
-            MessageBox.Show("Specify cannot be run in Safe Mode.", "Specify", MessageBoxButton.OK, MessageBoxImage.Error);
-            Environment.Exit(-1);
+            Settings.Headless = true;
+            AllocConsole();
+
+            if (bootType != 0)
+            {
+                Console.WriteLine("Specify cannot be run in Safe Mode.");
+                Environment.Exit(-1);
+            }
+
+            try
+            {
+                Utils.GetWmi("Win32_OperatingSystem");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Specify is unable to communicate with the Windows Management Instrumentation.\n{ex}");
+                Environment.Exit(-1);
+            }
+
+            foreach (var item in e.Args)
+            {
+                Console.WriteLine(item);
+                switch (item)
+                {
+                    case "-redact-username":
+                        Settings.RedactUsername = true;
+                        break;
+
+                    case "-redact-sn":
+                        Settings.RedactSerialNumber = true;
+                        break;
+
+                    case "-redact-odc":
+                        Settings.RedactOneDriveCommercial = true;
+                        break;
+
+                    case "-dont-upload":
+                        Settings.DontUpload = true;
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            // RUN PROGRAM
+            try
+            {
+                await Program.Main();
+            }
+            catch (Exception ex)
+            {
+                System.IO.File.WriteAllText(@"specify_hardfail.log", $"{ex}");
+                Console.ReadKey();
+
+            }
+
+            Console.ReadKey();
+            FreeConsole();
+            Environment.Exit(0);
         }
 
-        // Check that the WMI is functioning prior to loading the app.
-        // Specify is critically dependent on a functioning WMI Service. If it cannot talk to the WMI for whatever reason, Specify cannot run.
-        try
+        else
         {
-            Utils.GetWmi("Win32_OperatingSystem");
-        }
-        catch (Exception ex)
-        {
-            MessageBox.Show($"Specify is unable to communicate with the Windows Management Instrumentation.\n{ex}", "Specify", MessageBoxButton.OK, MessageBoxImage.Error);
-            Environment.Exit(-1);
+
+            if (bootType != 0)
+            {
+                MessageBox.Show("Specify cannot be run in Safe Mode.", "Specify", MessageBoxButton.OK, MessageBoxImage.Error);
+                Environment.Exit(-1);
+            }
+
+            // Check that the WMI is functioning prior to loading the app.
+            // Specify is critically dependent on a functioning WMI Service. If it cannot talk to the WMI for whatever reason, Specify cannot run.
+            try
+            {
+                Utils.GetWmi("Win32_OperatingSystem");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Specify is unable to communicate with the Windows Management Instrumentation.\n{ex}", "Specify", MessageBoxButton.OK, MessageBoxImage.Error);
+                Environment.Exit(-1);
+            }
+
+            StartupUri = new Uri("/specify_client;component/Frontend/Landing.xaml", UriKind.Relative);
         }
     }
 }

--- a/client/Frontend/App.xaml.cs
+++ b/client/Frontend/App.xaml.cs
@@ -81,8 +81,6 @@ public partial class App : Application
             catch (Exception ex)
             {
                 System.IO.File.WriteAllText(@"specify_hardfail.log", $"{ex}");
-                Console.ReadKey();
-
             }
 
             Console.ReadKey();

--- a/client/Monolith.cs
+++ b/client/Monolith.cs
@@ -275,9 +275,6 @@ public class Monolith
                 }
                 break;
         }
-
-        Console.WriteLine("Press any key to exit.");
-        Console.ReadKey();
     }
 
     public struct MonolithMeta

--- a/client/Monolith.cs
+++ b/client/Monolith.cs
@@ -194,8 +194,6 @@ public class Monolith
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("\nCould not upload. The file has been saved to specify_specs.json.");
                 Console.WriteLine($"Please go to {specifiedUploadDomain} to upload the file manually.");
-                Console.WriteLine("Press any key to exit.");
-                Console.ReadKey();
                 return null;
             }
             var location = response.Headers.Location.ToString();
@@ -220,19 +218,35 @@ public class Monolith
         switch (state)
         {
             case ProgramDoneState.Normal:
-                App.Current.Dispatcher.BeginInvoke(new Action(() =>
+                if (!Settings.Headless)
                 {
-                    var main = App.Current.MainWindow as Landing;
-                    main.ProgramFinalize();
-                }));
-                break;
+                    App.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        var main = App.Current.MainWindow as Landing;
+                        main.ProgramFinalize();
+                    }));
+                } else
+                {
+                    Console.WriteLine("Specify is done.");
+                    Console.WriteLine("Specify has uploaded the result to spec-ify.com, the link should be in your clipboard.");
+                }
+                    break;
 
             case ProgramDoneState.NoUpload:
-                App.Current.Dispatcher.BeginInvoke(new Action(() =>
+                if (!Settings.Headless)
                 {
-                    var main = App.Current.MainWindow as Landing;
-                    main.ProgramFinalizeNoUpload();
-                }));
+                    App.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        var main = App.Current.MainWindow as Landing;
+                        main.ProgramFinalizeNoUpload();
+                    }));
+                }
+                else
+                {
+                    Console.WriteLine("Specify is done.");
+                    Console.WriteLine("The result which is specify-specs.json is outputted into the same folder as the program.");
+                    Console.WriteLine("Please upload it manually to spec-ify.com or send over the file.");
+                }
                 break;
 
             case ProgramDoneState.UploadFailed:
@@ -244,13 +258,26 @@ public class Monolith
                 break;
 
             case ProgramDoneState.ProgramFailed:
-                App.Current.Dispatcher.BeginInvoke(new Action(() =>
+                if (!Settings.Headless)
                 {
-                    var main = App.Current.MainWindow as Landing;
-                    main.ProgramFailed();
-                }));
+                    App.Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        var main = App.Current.MainWindow as Landing;
+                        main.ProgramFailed();
+                    }));
+                }
+                else
+                {
+                    Console.WriteLine("Something went wrong...");
+                    Console.WriteLine("Specify ran into an error. It will try to continue, but the data may be incomplete.");
+                    Console.WriteLine("An error log named specify-debug.log has been created in the same folder as the program.");
+                    Console.WriteLine("Please make an issue on https://github.com/Spec-ify/specify/issues/new, or send over the file to us. Thanks!");
+                }
                 break;
         }
+
+        Console.WriteLine("Press any key to exit.");
+        Console.ReadKey();
     }
 
     public struct MonolithMeta

--- a/client/Settings.cs
+++ b/client/Settings.cs
@@ -6,6 +6,7 @@ public static class Settings
     public static bool RedactSerialNumber { get; set; } = false;
     public static bool RedactOneDriveCommercial { get; set; } = false;
     public static bool DontUpload { get; set; } = false;
+    public static bool Headless { get; set; } = false;
     public static bool LocalCulture { get; set; } = false;
     public static bool EnableDebug = false; // Deliberately not a property.
 }

--- a/client/data/Methods/System.cs
+++ b/client/data/Methods/System.cs
@@ -348,13 +348,29 @@ public static partial class Cache
         }
 
         await LogEventAsync("Dump Upload Requested.", Region.System);
-        if (MessageBox.Show("Would you like to upload your BSOD minidumps with your specs report?", "Minidumps detected", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.No)
+
+        if (!Settings.Headless)
         {
-            await LogEventAsync("Dump Upload Request Refused.", Region.System);
-            return;
+            if (MessageBox.Show("Would you like to upload your BSOD minidumps with your specs report?", "Minidumps detected", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.No)
+            {
+                await LogEventAsync("Dump Upload Request Refused.", Region.System);
+                return;
+            }
+        } else
+        { 
+            /* Future K9, figure out how to display this when the entire log is printed to console
+             * should we add an option for silent runs, this is not a problem lol
+              
+            Console.WriteLine("Would you like to upload your BSOD minidumps with your specs report? (y, n)");
+            if (Console.Read() == 'n')
+            {
+                await LogEventAsync("Dump Upload Request Refused.", Region.System);
+                return;
+            }
+            */
         }
 
-        await LogEventAsync("Dump Upload Request Approved.", Region.System);
+            await LogEventAsync("Dump Upload Request Approved.", Region.System);
 
         Directory.CreateDirectory(TempFolder);
 

--- a/client/data/Methods/System.cs
+++ b/client/data/Methods/System.cs
@@ -357,7 +357,7 @@ public static partial class Cache
                 return;
             }
         } else
-        { 
+        {
             /* Future K9, figure out how to display this when the entire log is printed to console
              * should we add an option for silent runs, this is not a problem lol
               
@@ -368,6 +368,7 @@ public static partial class Cache
                 return;
             }
             */
+            return;
         }
 
             await LogEventAsync("Dump Upload Request Approved.", Region.System);

--- a/client/specify_client.csproj
+++ b/client/specify_client.csproj
@@ -25,6 +25,18 @@
   <PropertyGroup Condition="'$(TargetFrameworkVersion)' == 'v4.7.2'">
     <DefineConstants>$(DefineConstants);DOTNET_472</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32bit>false</Prefer32bit>
+    <OutputPath>bin\Debug\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -47,18 +59,6 @@
     <Prefer32bit>false</Prefer32bit>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <OutputPath>bin\Release\</OutputPath>
-    <PlatformTarget>x64</PlatformTarget>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32bit>false</Prefer32bit>
-    <OutputPath>bin\Debug\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
One of the feature requests was to make specify possible to run on command line without the GUI. While it probably would've been better to just convert this project back into a CLI that calls the GUI when needed, this is probably the easier method given the project's activity.

When run on the command line with `-h` as one of the arguments, specify will open a separate console window where the debug log will be shown (couldn't be bothered to bring back the original TUI, but as a proof of concept, it works). It then waits for the user with the output text found in the GUI version to exit the app.

A limitation of this is because of the task-based nature of the collection system, I couldn't figure out how to display Upload Minidumps prompt properly. In code, I disabled Minidump collection entirely.