### PR TITLE
Redact networking option

### DIFF
--- a/client/Frontend/App.xaml.cs
+++ b/client/Frontend/App.xaml.cs
@@ -64,6 +64,10 @@ public partial class App : Application
                         Settings.RedactOneDriveCommercial = true;
                         break;
 
+                    case "-redact-networking":
+                        Settings.RedactNetworking = true;
+                        break;
+
                     case "-dont-upload":
                         Settings.DontUpload = true;
                         break;

--- a/client/Frontend/StartButtons.xaml
+++ b/client/Frontend/StartButtons.xaml
@@ -118,6 +118,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="1*" />
                     <RowDefinition Height="1*" />
+                    <RowDefinition Height="1*" />
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
@@ -187,6 +188,23 @@
                               HorizontalAlignment="Center"
                               VerticalAlignment="Center" Content=" Don't Upload  "
                               Checked="UploadOff" Unchecked="UploadOn"
+                              Style="{DynamicResource CheckBoxStyle1}"
+                              Width="120" Foreground="White"
+                              FontFamily="Consolas" VerticalContentAlignment="Center"/>
+
+                </Grid>
+
+                <Grid Grid.Row="2" Grid.Column="0">
+
+                    <Border CornerRadius="8"
+                            BorderThickness="2"
+                            BorderBrush="#576277"
+                            Margin="2"/>
+
+                    <CheckBox Name="RedactNetworkingCheckbox"
+                              HorizontalAlignment="Center"
+                              VerticalAlignment="Center" Content=" Redact Network"
+                              Checked="RedactNetworkingOn" Unchecked="RedactNetworkingOff"
                               Style="{DynamicResource CheckBoxStyle1}"
                               Width="120" Foreground="White"
                               FontFamily="Consolas" VerticalContentAlignment="Center"/>

--- a/client/Frontend/StartButtons.xaml
+++ b/client/Frontend/StartButtons.xaml
@@ -133,7 +133,8 @@
                             BorderBrush="#576277"
                             Margin="2"/>
 
-                    <CheckBox HorizontalAlignment="Center"
+                    <CheckBox Name="UsernamesCheckbox"
+                              HorizontalAlignment="Center"
                               VerticalAlignment="Center" Content="Remove Usernames"
                               Checked="UsernameOn" Unchecked="UsernameOff"
                               Style="{DynamicResource CheckBoxStyle1}"
@@ -167,13 +168,13 @@
                             Margin="2"/>
 
                     <CheckBox Name="DebugLogCheckbox"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center" Content=" Enable Debug  &#x0a;    Logging"
-                    Checked="DebugLogToggleOn" Unchecked="DebugLogToggleOff"
-                    Style="{DynamicResource CheckBoxStyle1}"
-                    Grid.Row="2" Grid.Column="3"
-                    Width="120" Foreground="White"
-                    FontFamily="Consolas"/>
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center" Content=" Enable Debug  &#x0a;    Logging"
+                            Checked="DebugLogToggleOn" Unchecked="DebugLogToggleOff"
+                            Style="{DynamicResource CheckBoxStyle1}"
+                            Grid.Row="2" Grid.Column="3"
+                            Width="120" Foreground="White"
+                            FontFamily="Consolas"/>
 
                 </Grid>
 
@@ -201,9 +202,9 @@
                             BorderBrush="#576277"
                             Margin="2"/>
 
-                    <CheckBox Name="RedactNetworkingCheckbox"
+                    <CheckBox Name="NetworkingCheckbox"
                               HorizontalAlignment="Center"
-                              VerticalAlignment="Center" Content=" Redact Network"
+                              VerticalAlignment="Center" Content=" Remove Networking"
                               Checked="RedactNetworkingOn" Unchecked="RedactNetworkingOff"
                               Style="{DynamicResource CheckBoxStyle1}"
                               Width="120" Foreground="White"

--- a/client/Frontend/StartButtons.xaml.cs
+++ b/client/Frontend/StartButtons.xaml.cs
@@ -61,6 +61,16 @@ public partial class StartButtons : Page
         Settings.RedactSerialNumber = false;
     }
 
+    private void RedactNetworkingOn(object sender, RoutedEventArgs e)
+    {
+        Settings.RedactNetworking = true;
+    }
+
+    private void RedactNetworkingOff(object sender, RoutedEventArgs e)
+    {
+        Settings.RedactNetworking = false;
+    }
+
     private void DebugLogToggleOn(object sender, RoutedEventArgs e)
     {
         Settings.EnableDebug = true;

--- a/client/Settings.cs
+++ b/client/Settings.cs
@@ -5,6 +5,7 @@ public static class Settings
     public static bool RedactUsername { get; set; } = false;
     public static bool RedactSerialNumber { get; set; } = false;
     public static bool RedactOneDriveCommercial { get; set; } = false;
+    public static bool RedactNetworking { get; set; } = false;
     public static bool DontUpload { get; set; } = false;
     public static bool Headless { get; set; } = false;
     public static bool LocalCulture { get; set; } = false;

--- a/client/data/Methods/Network.cs
+++ b/client/data/Methods/Network.cs
@@ -20,21 +20,36 @@ public static partial class Cache
         {
             DebugLog.Region region = DebugLog.Region.Networking;
             await DebugLog.StartRegion(region);
-            NetAdapters = Utils.GetWmi("Win32_NetworkAdapterConfiguration",
-                "Description, DHCPEnabled, DHCPServer, DNSDomain, DNSDomainSuffixSearchOrder, DNSHostName, "
-                + "DNSServerSearchOrder, IPEnabled, IPAddress, IPSubnet, DHCPLeaseObtained, DHCPLeaseExpires, "
-                + "DefaultIPGateway, MACAddress, InterfaceIndex");
+            if (Settings.RedactNetworking)
+            {
+                NetAdapters = new List<Dictionary<string, object>>();
+                NetAdapters2 = new List<Dictionary<string, object>>();
+                IPRoutes = new List<Dictionary<string, object>>();
+                TCPConnections = new List<TCPConnection>();
+                UDPEndpoints = new List<Dictionary<string, object>>();
+                HostsFile = "";
+                HostsFileHash = "";
 
-            NetAdapters2 = Utils.GetWmi("MSFT_NetAdapter",
-                "*",
-                @"root\standardcimv2");
-            IPRoutes = Utils.GetWmi("Win32_IP4RouteTable",
-                "Description, Destination, Mask, NextHop, Metric1, InterfaceIndex");
+                await DebugLog.LogEventAsync("Networking redaction enabled. NICs, routes, hosts file, and network connections were skipped.", region);
+            }
+            else
+            {
+                NetAdapters = Utils.GetWmi("Win32_NetworkAdapterConfiguration",
+                    "Description, DHCPEnabled, DHCPServer, DNSDomain, DNSDomainSuffixSearchOrder, DNSHostName, "
+                    + "DNSServerSearchOrder, IPEnabled, IPAddress, IPSubnet, DHCPLeaseObtained, DHCPLeaseExpires, "
+                    + "DefaultIPGateway, MACAddress, InterfaceIndex");
 
-            await DebugLog.LogEventAsync("Networking WMI Information Retrieved.", region);
+                NetAdapters2 = Utils.GetWmi("MSFT_NetAdapter",
+                    "*",
+                    @"root\standardcimv2");
+                IPRoutes = Utils.GetWmi("Win32_IP4RouteTable",
+                    "Description, Destination, Mask, NextHop, Metric1, InterfaceIndex");
 
-            GetAdapterProperties();
-            CombineAdapterInformation();
+                await DebugLog.LogEventAsync("Networking WMI Information Retrieved.", region);
+
+                GetAdapterProperties();
+                CombineAdapterInformation();
+            }
 
             var rssWmi = Utils.GetWmi("MSFT_NetOffloadGlobalSetting", "ReceiveSideScaling", "root\\standardcimv2").FirstOrDefault();
             rssWmi.TryWmiRead("ReceiveSideScaling", out byte? rcvSideScaling);
@@ -45,14 +60,17 @@ public static partial class Cache
 
             AutoTuningLevelLocal = GetAutoTuningLevels();
 
-            HostsFile = GetHostsFile();
-            HostsFileHash = GetHostsFileHash();
-            await DebugLog.LogEventAsync("Hosts file retrieved.", region);
+            if (!Settings.RedactNetworking)
+            {
+                HostsFile = GetHostsFile();
+                HostsFileHash = GetHostsFileHash();
+                await DebugLog.LogEventAsync("Hosts file retrieved.", region);
 
-            TCPConnections = GetTCPConnections();
-            UDPEndpoints = Utils.GetWmi("MSFT_NetUDPEndpoint", "LocalAddress,LocalPort,OwningProcess",
-                @"root\standardcimv2");
-            await DebugLog.LogEventAsync("Network Connections Information retrieved.", region);
+                TCPConnections = GetTCPConnections();
+                UDPEndpoints = Utils.GetWmi("MSFT_NetUDPEndpoint", "LocalAddress,LocalPort,OwningProcess",
+                    @"root\standardcimv2");
+                await DebugLog.LogEventAsync("Network Connections Information retrieved.", region);
+            }
 
             await DebugLog.EndRegion(DebugLog.Region.Networking);
         }


### PR DESCRIPTION
I would like to add a "Remote networking" button to allow adoption in more restrictive use cases. This will blank the Network connections, Routes table, and Hosts file. The NIC box will appear as "Disconnected".

I checked that it works correctly with the toggle both on and off on my Windows host. 